### PR TITLE
Back Button Support

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import { useBackHandler } from '@react-native-community/hooks';
+import React, { useRef } from 'react';
 import WebView from 'react-native-webview';
 
 const uri = __DEV__
@@ -6,8 +7,19 @@ const uri = __DEV__
   : 'file:///android_asset/build/index.html';
 
 const App = () => {
+  const webview = useRef();
+
+  useBackHandler(() => {
+    if (!webview.current) {
+      return false;
+    }
+    webview.current.goBack();
+    return true;
+  });
+
   return (
     <WebView
+      ref={webview}
       source={{ uri }}
       allowFileAccess
       setBuiltInZoomControls={false}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "install:android": "adb install -r outputs/android/apk/app-release.apk"
   },
   "dependencies": {
+    "@react-native-community/hooks": "^2.8.1",
     "react": "17.0.2",
     "react-native": "0.68.1",
     "react-native-webview": "^11.18.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,6 +1091,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.2.0.tgz#7d6d789ae8edf73dc9bed1246cd48277edea8066"
   integrity sha512-o6aam+0Ug1xGK3ABYmBm0B1YuEKfM/5kaoZO0eHbZwSpw9UzDX4G5y4Nx/K20FHqUmJHkZmLvOUFYwN4N+HqKA==
 
+"@react-native-community/hooks@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/hooks/-/hooks-2.8.1.tgz#6e785431db49318048fdd14b601998437b6cc200"
+  integrity sha512-DCmCIC0Gn9m6K0Mlg2MwNmTxMEpBu5lTLsI6b/XUAv/vLGa6o+X7RhCai4FWeqkjCU36+ZOwaLzDo4NBWMXaoQ==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"


### PR DESCRIPTION
Pressing the back button of the device will now interact with the history-api of the web-view instead of exiting the app.

Branch created from https://github.com/vocascan/vocascan-mobile/pull/7, so its changes are included here